### PR TITLE
add min-release-age in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 @akashic:registry=https://registry.npmjs.org
 @akashic-extension:registry=https://registry.npmjs.org
+min-release-age=7


### PR DESCRIPTION
This PR adds `min-release-age=7` to .npmrc as requested.